### PR TITLE
Add ignoretag feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,3 +2,5 @@
 
 This plugin displays progress information for task lists and automatically
 updates parent task checkboxes when all of their subtasks change state.
+Pages can be excluded from calculations by tagging them with a custom ignore tag
+configured in the plugin settings.

--- a/main.ts
+++ b/main.ts
@@ -258,7 +258,7 @@ export default class MyPlugin extends Plugin {
         try {
             const content = await this.app.vault.read(abstract);
             const prev = this.fileStates.get(path);
-            const result = updateParentStatuses(content, prev, path, root);
+            const result = updateParentStatuses(content, prev, path, root, this.settings.ignoreTag);
             this.fileStates.set(path, result.state);
             if (result.content !== content) {
                 this.skipModify = true;

--- a/src/auto-parent.ts
+++ b/src/auto-parent.ts
@@ -55,6 +55,9 @@ function parseTasks(
           : `${pageName}.md`;
         const linkPath = path.resolve(currentDir, fileName);
         if (fs.existsSync(linkPath)) {
+          if (builder.shouldIgnoreFile(linkPath)) {
+            continue;
+          }
           try {
             const tree = builder.buildFromFile(linkPath);
             const counts = tree.getCounts();
@@ -91,14 +94,15 @@ export function updateParentStatuses(
   content: string,
   prevState?: Map<number, boolean>,
   filePath?: string,
-  rootDir?: string
+  rootDir?: string,
+  ignoreTag: string = 'ignoretasktree'
 ): UpdateResult {
   const lines = content.split(/\r?\n/);
   let builder: TaskTreeBuilder | undefined = undefined;
   let dir: string | undefined = undefined;
   if (filePath && rootDir) {
     dir = path.dirname(path.isAbsolute(filePath) ? filePath : path.resolve(rootDir, filePath));
-    builder = new TaskTreeBuilder(rootDir);
+    builder = new TaskTreeBuilder(rootDir, ignoreTag);
   }
   const tasks = parseTasks(lines, dir, builder);
 

--- a/src/task-tree-builder.ts
+++ b/src/task-tree-builder.ts
@@ -44,6 +44,20 @@ export class TaskTreeBuilder {
   }
 
   /**
+   * Returns true if the given file contains the ignore tag.
+   */
+  public shouldIgnoreFile(filePath: string): boolean {
+    const absPath = path.isAbsolute(filePath)
+      ? filePath
+      : path.resolve(this.rootDir, filePath);
+    if (!fs.existsSync(absPath)) {
+      return false;
+    }
+    const content = fs.readFileSync(absPath, 'utf-8');
+    return content.includes(`#${this.ignoreTag}`);
+  }
+
+  /**
    * Builds a TaskTree for the given markdown file path.
    * @param filePath Relative or absolute path to the markdown file.
    */

--- a/tests/auto-parent-linked.test.ts
+++ b/tests/auto-parent-linked.test.ts
@@ -18,4 +18,11 @@ describe('updateParentStatuses with links', () => {
     const result = updateParentStatuses(content, undefined, filePath, root);
     expect(result.content.trim()).toBe('- [ ] Parent Task [[subpage]]');
   });
+
+  test('ignores linked page with custom ignore tag', () => {
+    const filePath = path.join(root, 'ignore-custom-start.md');
+    const content = fs.readFileSync(filePath, 'utf8');
+    const result = updateParentStatuses(content, undefined, filePath, root, 'customignore');
+    expect(result.content.trim()).toBe('- [x] Parent Task [[ignore-custom]]');
+  });
 });

--- a/tests/fixtures/ignore-custom-start.md
+++ b/tests/fixtures/ignore-custom-start.md
@@ -1,0 +1,1 @@
+- [x] Parent Task [[ignore-custom]]

--- a/tests/fixtures/ignore-custom.md
+++ b/tests/fixtures/ignore-custom.md
@@ -1,0 +1,3 @@
+#customignore
+- [ ] Task A
+- [x] Task B

--- a/tests/task-tree-builder.test.ts
+++ b/tests/task-tree-builder.test.ts
@@ -79,6 +79,14 @@ describe('TaskTreeBuilder', () => {
     expect(tree.getCompletionString()).toBe('Complete 0% (0/1)');
   });
 
+  test('skips pages tagged with custom ignore tag', () => {
+    const customBuilder = new TaskTreeBuilder(undefined, 'customignore');
+    const file = __dirname + '/fixtures/ignore-custom.md';
+    const tree = customBuilder.buildFromFile(file);
+    expect(tree.getCounts()).toEqual({ total: 0, completed: 0 });
+    expect(tree.getCompletionString()).toBe('No tasks');
+  });
+
   test('build tree from page with multiple separate lists', () => {
     const file = __dirname + '/fixtures/multi.md';
     const tree = builder.buildFromFile(file);


### PR DESCRIPTION
## Summary
- allow custom ignore tag for task tree builder and auto-parent
- skip links to pages containing the ignore tag
- expose ignoreTag setting for automatic parent updates
- document ignore tag usage
- test custom ignore tag handling

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6843e6c1ce28832db9e9ed59776f7229