### PR TITLE
Fix vault path traversal

### DIFF
--- a/main.ts
+++ b/main.ts
@@ -7,6 +7,7 @@ import {
     Setting,
     TFile      // added TFile
 } from 'obsidian';
+import * as path from 'path';
 import { editorLivePreviewField } from "obsidian"; // Required for CM6 editor extensions
 import { Extension, RangeSetBuilder } from '@codemirror/state';
 import { ViewPlugin, Decoration, DecorationSet, ViewUpdate, WidgetType, EditorView } from '@codemirror/view';
@@ -27,6 +28,16 @@ const DEFAULT_SETTINGS: MyPluginSettings = {
     inlineFieldName: 'COMPLETE',
     representation: 'Complete {percentage}% ({completed}/{total})',
     ignoreTag: 'ignoretasktree',
+};
+
+function resolveVaultPath(root: string, filePath: string): string | undefined {
+    const abs = path.resolve(root, filePath);
+    const rel = path.relative(root, abs);
+    if (rel.startsWith('..') || path.isAbsolute(rel)) {
+        console.warn(`Skipping invalid path outside vault: ${filePath}`);
+        return undefined;
+    }
+    return abs;
 }
 
 export default class MyPlugin extends Plugin {
@@ -69,8 +80,10 @@ export default class MyPlugin extends Plugin {
                     } else {
                         filePath = context.sourcePath ?? '';
                     }
+                    const resolved = resolveVaultPath(vaultRoot, filePath);
                     try {
-                        const tree = builder.buildFromFile(filePath);
+                        if (!resolved) throw new Error('invalid');
+                        const tree = builder.buildFromFile(resolved);
                         const counts = tree.getCounts();
                         const rawString = tree.getCompletionString();
                         let display: string;
@@ -174,9 +187,11 @@ export default class MyPlugin extends Plugin {
                                const active = plugin.app.workspace.getActiveFile();
                                filePath = active?.path || '';
                            }
+                            const resolved = resolveVaultPath(vaultRoot, filePath);
                             let displayText: string;
                             try {
-                                const tree = treeBuilder.buildFromFile(filePath);
+                                if (!resolved) throw new Error('invalid');
+                                const tree = treeBuilder.buildFromFile(resolved);
                                 const counts = tree.getCounts();
                                 const rawString = tree.getCompletionString();
                                 if (counts.total === 0) {

--- a/src/task-tree-builder.ts
+++ b/src/task-tree-builder.ts
@@ -35,6 +35,11 @@ export class TaskTreeBuilder {
   private hasFileCycle: boolean = false;  // flag for cycle in page links
   private fileStack: string[] = [];  // track current file recursion stack
 
+  private isPathInsideRoot(p: string): boolean {
+    const rel = path.relative(this.rootDir, p);
+    return !rel.startsWith('..') && !path.isAbsolute(rel);
+  }
+
   /**
    * @param rootDir Base directory for resolving relative paths (e.g., vault root in Obsidian).
    */
@@ -50,6 +55,9 @@ export class TaskTreeBuilder {
     const absPath = path.isAbsolute(filePath)
       ? filePath
       : path.resolve(this.rootDir, filePath);
+    if (!this.isPathInsideRoot(absPath)) {
+      return false;
+    }
     if (!fs.existsSync(absPath)) {
       return false;
     }
@@ -65,6 +73,9 @@ export class TaskTreeBuilder {
     const absPath = path.isAbsolute(filePath)
       ? filePath
       : path.resolve(this.rootDir, filePath);
+    if (!this.isPathInsideRoot(absPath)) {
+      throw new Error(`Invalid path outside root: ${filePath}`);
+    }
     // detect root invocation to reset state
     const isRootCall = this.fileStack.length === 0;
     if (isRootCall) {
@@ -123,7 +134,7 @@ export class TaskTreeBuilder {
         // preserve .md extension if present
         const fileName = pageName.toLowerCase().endsWith('.md') ? pageName : `${pageName}.md`;
         const linkPath = path.resolve(currentDir, fileName);
-        if (fs.existsSync(linkPath)) {
+        if (this.isPathInsideRoot(linkPath) && fs.existsSync(linkPath)) {
           // detect page link cycles by checking recursion stack
           if (this.fileStack.includes(linkPath)) {
             // set file-level cycle flag

--- a/tests/fixtures/path-traversal.md
+++ b/tests/fixtures/path-traversal.md
@@ -1,0 +1,1 @@
+- [ ] Danger [[../../etc/passwd]]

--- a/tests/task-tree-builder.test.ts
+++ b/tests/task-tree-builder.test.ts
@@ -101,4 +101,13 @@ describe('TaskTreeBuilder', () => {
     expect(tree.getCompletionString()).toBe('Complete 40% (2/5)');
   });
 
+  test('ignores links that escape the vault root', () => {
+    const root = __dirname + '/fixtures';
+    const customBuilder = new TaskTreeBuilder(root);
+    const file = root + '/path-traversal.md';
+    const tree = customBuilder.buildFromFile(file);
+    expect(tree.getCounts()).toEqual({ total: 1, completed: 0 });
+    expect(tree.getCompletionString()).toBe('Complete 0% (0/1)');
+  });
+
 });


### PR DESCRIPTION
## Summary
- validate note links do not escape the vault directory
- warn and skip when invalid paths are encountered
- add regression test for `[[../../etc/passwd]]`

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68497bd5b318832d8bb4bd1354e5b107