### PR TITLE
Clarify ignoretasktree link test

### DIFF
--- a/tests/task-tree-builder.test.ts
+++ b/tests/task-tree-builder.test.ts
@@ -72,7 +72,7 @@ describe('TaskTreeBuilder', () => {
     expect(tree.getCounts()).toEqual({ total: 0, completed: 0 });
     expect(tree.getCompletionString()).toBe('No tasks');
   });
-  test('skips pages tagged with #ignoretasktree', () => {
+  test('skips tasks from linked pages tagged with #ignoretasktree', () => {
     const file = __dirname + '/fixtures/ignore-tasktree-start.md';
     const tree = builder.buildFromFile(file);
     expect(tree.getCounts()).toEqual({ total: 1, completed: 0 });


### PR DESCRIPTION
## Summary
- rename second `skips pages tagged with #ignoretasktree` test to clarify that it deals with linked pages

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684bf6f6b8c4832dbd1af5e5119aba9e