### PR TITLE
Fix auto completion for missing or empty linked pages

### DIFF
--- a/src/auto-parent.ts
+++ b/src/auto-parent.ts
@@ -46,31 +46,35 @@ function parseTasks(
       const matches = text.matchAll(linkRegex);
       let hasLink = false;
       let allLinkComplete = true;
-      for (const m of matches) {
-        console.log(`Found link: ${m[1]}`);
-        hasLink = true;
-        const rawLink = m[1];
-        const pageName = rawLink.split('|')[0].trim();
-        const fileName = pageName.toLowerCase().endsWith('.md')
-          ? pageName
-          : `${pageName}.md`;
-        const linkPath = path.resolve(currentDir, fileName);
-        if (fs.existsSync(linkPath)) {
-          if (builder.shouldIgnoreFile(linkPath)) {
-            continue;
-          }
-          try {
-            const tree = builder.buildFromFile(linkPath);
-            const counts = tree.getCounts();
-            if (counts.total != 0) {
-              const complete = counts.total > 0 && counts.total === counts.completed;
-              if (!complete) allLinkComplete = false;
+        for (const m of matches) {
+          console.log(`Found link: ${m[1]}`);
+          hasLink = true;
+          const rawLink = m[1];
+          const pageName = rawLink.split('|')[0].trim();
+          const fileName = pageName.toLowerCase().endsWith('.md')
+            ? pageName
+            : `${pageName}.md`;
+          const linkPath = path.resolve(currentDir, fileName);
+          if (fs.existsSync(linkPath)) {
+            if (builder.shouldIgnoreFile(linkPath)) {
+              continue;
             }
-          } catch {
+            try {
+              const tree = builder.buildFromFile(linkPath);
+              const counts = tree.getCounts();
+              if (counts.total === 0) {
+                allLinkComplete = false;
+              } else {
+                const complete = counts.total === counts.completed;
+                if (!complete) allLinkComplete = false;
+              }
+            } catch {
+              allLinkComplete = false;
+            }
+          } else {
             allLinkComplete = false;
           }
         }
-      }
       if (hasLink) {
         task.linkChildrenComplete = allLinkComplete;
       }

--- a/tests/auto-parent-linked.test.ts
+++ b/tests/auto-parent-linked.test.ts
@@ -26,21 +26,23 @@ describe('updateParentStatuses with links', () => {
     expect(result.content.trim()).toBe('- [x] Parent Task [[ignore-custom]]');
   });
 
-  test('checks parent when all subtasks are complete and linked page is not existin', () => {
+  test('leaves parent unchecked when linked page is missing', () => {
     const content = `- [ ] 1st level [[page-without-tasks]]
     - [ ] 2nd level
         - [x] 3rd level
     - [x] completed task`;
-    const result = updateParentStatuses(content, undefined, undefined, root);
-    expect(result.content.split(/\r?\n/)[0]).toBe('- [x] 1st level [[page-without-tasks]]');
+    const filePath = path.join(root, 'dummy.md');
+    const result = updateParentStatuses(content, undefined, filePath, root);
+    expect(result.content.split(/\r?\n/)[0]).toBe('- [ ] 1st level [[page-without-tasks]]');
   });
 
-    test('checks parent when all subtasks are complete and linked page does not have tasks', () => {
+  test('leaves parent unchecked when linked page has no tasks', () => {
     const content = `- [ ] 1st level [[no-tasks]]
     - [ ] 2nd level
         - [x] 3rd level
     - [x] completed task`;
-    const result = updateParentStatuses(content, undefined, undefined, root);
-    expect(result.content.split(/\r?\n/)[0]).toBe('- [x] 1st level [[no-tasks]]');
+    const filePath = path.join(root, 'dummy.md');
+    const result = updateParentStatuses(content, undefined, filePath, root);
+    expect(result.content.split(/\r?\n/)[0]).toBe('- [ ] 1st level [[no-tasks]]');
   });
 });


### PR DESCRIPTION
## Summary
- avoid marking linked tasks complete when target page is missing or has no tasks
- adjust auto-parent link tests

## Testing
- `npm install`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685050b18e74832d8c16c9801209ccc3