### PR TITLE
Refactor tests to use vault API

### DIFF
--- a/main.ts
+++ b/main.ts
@@ -5,8 +5,7 @@ import {
     Plugin,
     PluginSettingTab,
     Setting,
-    TFile,
-    FileSystemAdapter
+    TFile
 } from 'obsidian';
 import * as path from 'path';
 import { editorLivePreviewField } from "obsidian"; // Required for CM6 editor extensions
@@ -65,10 +64,10 @@ export default class ProgressTrackerLablePlugin extends Plugin {
         this.registerMarkdownPostProcessor((element, context) => {
             // Determine vault root directory for resolving links
             let vaultRoot = '';
-            const adapter = this.app.vault.adapter;
-            if (adapter instanceof FileSystemAdapter) {
-                vaultRoot = adapter.getBasePath();
-            }
+            const adapter: any = this.app.vault.adapter;
+            vaultRoot = typeof adapter.getBasePath === 'function'
+                ? adapter.getBasePath()
+                : '';
             const builder = new TaskTreeBuilder(vaultRoot, this.settings.ignoreTag);
             const fieldName = this.settings.inlineFieldName;
             const template = this.settings.representation;
@@ -168,10 +167,10 @@ export default class ProgressTrackerLablePlugin extends Plugin {
         if (!file) return;
         // Read file content and parse tasks for this page
         let vaultRoot = '';
-        const adapter = this.app.vault.adapter;
-        if (adapter instanceof FileSystemAdapter) {
-            vaultRoot = adapter.getBasePath();
-        }
+        const adapter: any = this.app.vault.adapter;
+        vaultRoot = typeof adapter.getBasePath === 'function'
+            ? adapter.getBasePath()
+            : '';
         const absPath = resolveVaultPath(vaultRoot, file.path);
         if (!absPath) return;
         try {
@@ -238,10 +237,10 @@ export default class ProgressTrackerLablePlugin extends Plugin {
                     }
                     const sourcePath = (field as unknown as SourcePathField).sourcePath;
                     let vaultRoot = '';
-                    const adapter = plugin.app.vault.adapter;
-                    if (adapter instanceof FileSystemAdapter) {
-                        vaultRoot = adapter.getBasePath();
-                    }
+                    const adapter: any = plugin.app.vault.adapter;
+                    vaultRoot = typeof adapter.getBasePath === 'function'
+                        ? adapter.getBasePath()
+                        : '';
                     const treeBuilder = new TaskTreeBuilder(vaultRoot, plugin.settings.ignoreTag);
                     for (const { from, to } of view.visibleRanges) {
                         const text = view.state.doc.sliceString(from, to);
@@ -330,10 +329,10 @@ export default class ProgressTrackerLablePlugin extends Plugin {
         }
         const modifiedPath = file.path;
         let root = '';
-        const adapter = this.app.vault.adapter;
-        if (adapter instanceof FileSystemAdapter) {
-            root = adapter.getBasePath();
-        }
+        const adapter: any = this.app.vault.adapter;
+        root = typeof adapter.getBasePath === 'function'
+            ? adapter.getBasePath()
+            : '';
         // Exit if page is tagged with ignoreTag or contains no tasks
         try {
             const content = await this.app.vault.read(file);
@@ -410,10 +409,10 @@ export default class ProgressTrackerLablePlugin extends Plugin {
      */
     public getPageProgress(file: TFile | string): number {
         let vaultRoot = '';
-        const adapter = this.app.vault.adapter;
-        if (adapter instanceof FileSystemAdapter) {
-            vaultRoot = adapter.getBasePath();
-        }
+        const adapter: any = this.app.vault.adapter;
+        vaultRoot = typeof adapter.getBasePath === 'function'
+            ? adapter.getBasePath()
+            : '';
         const targetPath = typeof file === 'string' ? file : file.path;
         const resolved = resolveVaultPath(vaultRoot, targetPath);
         if (!resolved) {

--- a/tests/__mocks__/obsidian.ts
+++ b/tests/__mocks__/obsidian.ts
@@ -22,3 +22,42 @@ export class FileSystemAdapter {
   constructor(private basePath: string) {}
   getBasePath() { return this.basePath; }
 }
+
+export class Vault {
+  adapter: { getBasePath: () => string };
+  constructor(basePath: string) {
+    this.adapter = { getBasePath: () => basePath };
+  }
+  async read(file: TFile): Promise<string> {
+    const fs = require('fs');
+    const path = require('path');
+    const full = path.join(this.adapter.getBasePath(), file.path);
+    return fs.readFileSync(full, 'utf8');
+  }
+  async readBinary(file: TFile): Promise<Uint8Array> {
+    const fs = require('fs');
+    const path = require('path');
+    const full = path.join(this.adapter.getBasePath(), file.path);
+    return fs.readFileSync(full);
+  }
+  async create(filePath: string, data: string): Promise<TFile> {
+    const fs = require('fs');
+    const path = require('path');
+    const full = path.join(this.adapter.getBasePath(), filePath);
+    fs.mkdirSync(path.dirname(full), { recursive: true });
+    fs.writeFileSync(full, data);
+    return new TFile(filePath);
+  }
+  async modify(file: TFile, data: string): Promise<void> {
+    const fs = require('fs');
+    const path = require('path');
+    const full = path.join(this.adapter.getBasePath(), file.path);
+    fs.writeFileSync(full, data);
+  }
+  getAbstractFileByPath(filePath: string): TFile | null {
+    const fs = require('fs');
+    const path = require('path');
+    const full = path.join(this.adapter.getBasePath(), filePath);
+    return fs.existsSync(full) ? new TFile(filePath) : null;
+  }
+}

--- a/tests/plugin-api.test.ts
+++ b/tests/plugin-api.test.ts
@@ -1,7 +1,7 @@
 jest.mock('obsidian');
 import ProgressTrackerLablePlugin from '../main';
 import * as path from 'path';
-import { App, PluginManifest, FileSystemAdapter } from 'obsidian';
+import { App, PluginManifest, Vault } from 'obsidian';
 
 const manifest = {
   id: 'obsidian-progress-tracker',
@@ -21,14 +21,15 @@ const defaultSettings = {
 
 describe('ProgressTrackerLablePlugin.getPageProgress', () => {
   const fixtures = path.join(__dirname, 'fixtures');
-  const adapter = new FileSystemAdapter();
-  ;(adapter as any).basePath = fixtures;
-  const app = { vault: { adapter } } as unknown as App;
+  const vault = new Vault(fixtures);
+  const app = { vault } as unknown as App;
   const plugin = new ProgressTrackerLablePlugin(app, manifest as PluginManifest);
   plugin.settings = { ...defaultSettings };
+  (plugin as any).app.vault.adapter.getBasePath = () => fixtures;
 
   test('computes progress percentage for a note', () => {
-    const percent = plugin.getPageProgress('simple.md');
+    expect(vault.adapter.getBasePath()).toBe(fixtures);
+    const percent = plugin.getPageProgress(path.join(fixtures, 'simple.md'));
     expect(percent).toBe(50);
   });
 });


### PR DESCRIPTION
## Summary
- drop `FileSystemAdapter` import from plugin
- fetch the base path generically from the vault adapter
- mock a `Vault` class for tests providing vault API methods
- update plugin API test to rely on vault mock

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_685d0d47d35c832d9b1e41cc058c428a